### PR TITLE
adding ForwardAgent=yes for scp between remote machines

### DIFF
--- a/luigi/contrib/ssh.py
+++ b/luigi/contrib/ssh.py
@@ -167,7 +167,8 @@ class RemoteFileSystem(luigi.target.FileSystem):
         cmd = ["scp", "-q", "-B", "-C", "-o", "ControlMaster=no"]
         if self.remote_context.no_host_key_check:
             cmd.extend(['-o', 'UserKnownHostsFile=/dev/null',
-                        '-o', 'StrictHostKeyChecking=no'])
+                        '-o', 'StrictHostKeyChecking=no',
+                        '-o', 'ForwardAgent=yes'])
         if self.remote_context.key_file:
             cmd.extend(["-i", self.remote_context.key_file])
         if self.remote_context.port:


### PR DESCRIPTION
Very basic addition to allow for scp between two remote machines if ssh-agent key forwarding is setup. A little bit of a hack, but works.

you can pass the full host:file path as your "local_path" when using put(), rather than the path to the physically local file.
ex:

```
RemoteFileSystem(
    "somehost",
    username="myuser",
    ...,
    no_host_key_check=True
).put("myuser@host1:/tmp/file", "/tmp/file")
```

Might be good to eventually allow for many ssh_config values to be passed in a list

```
[
  "StrictHostKeyChecking=no",
  "UserKnownHostsFile=/dev/null", 
  "ForwardAgent=yes",
  ...
]
```
